### PR TITLE
[Update]カート機能のログイン者のみの制限

### DIFF
--- a/app/controllers/public/carts_controller.rb
+++ b/app/controllers/public/carts_controller.rb
@@ -1,4 +1,5 @@
 class Public::CartsController < ApplicationController
+  before_action :authenticate_customer!
 
   def index
     @cart = Cart.new


### PR DESCRIPTION
・商品をカートに入れる機能をログインユーザーのみの使用に制限
ログイン画面へ移行させる使用に修正