### PR TITLE
[Update]サインイン・ログイン・ログアウト後の移動先修正、レイアウト調整

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   # GET /resource/sign_in
   # def new
@@ -24,4 +24,15 @@ class Admin::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+
+  private
+
+  def after_sign_in_path_for(resource)
+    admin_root_path
+  end
+
+  def after_sign_out_path_for(resource)
+    admin_session_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+
   private
 
   def configure_permitted_parameters

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -59,4 +59,10 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  private
+
+  def after_sign_up_path_for(resource)
+    my_page_customers_path
+  end
 end

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -20,6 +20,17 @@ class Public::SessionsController < Devise::SessionsController
   # end
 
 
+  private
+
+  def after_sign_in_path_for(resource)
+    root_path
+  end
+
+  def after_sign_out_path_for(resource)
+    root_path
+  end
+
+
   protected
 
   def reject_deleted_customer

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -7,13 +7,13 @@
     <%= form_with model: @customer, url: information_customers_path do |f| %>
       <div class="field row mt-2">
         <p class="col-3">名前</p>
-        <%= f.text_field :last_name, autofocus: true, placeholder: '令和' %>
+        <%= f.text_field :last_name, autofocus: true, placeholder: '令和', class: "mr-md-5" %>
         <%= f.text_field :first_name, autofocus: true, placeholder: '道子' %>
       </div>
 
       <div class="field row mt-2">
         <p class="col-3">フリガナ</p>
-        <%= f.text_field :last_name_kana, autofocus: true, placeholder: 'レイワ' %>
+        <%= f.text_field :last_name_kana, autofocus: true, placeholder: 'レイワ', class: "mr-md-5" %>
         <%= f.text_field :first_name_kana, autofocus: true, placeholder: 'ミチコ' %>
       </div>
 
@@ -39,7 +39,7 @@
 
       <div class="actions row mt-3">
         <div class="col-3"></div>
-        <%= f.submit "編集内容を保存",class: "btn btn-sm btn-success px-5" %>
+        <%= f.submit "編集内容を保存",class: "btn btn-sm btn-success px-5 mr-md-5" %>
         <div class="col-1"></div>
         <%= link_to "退会する", unsubscribe_customers_path, class: "btn btn-sm btn-danger px-3" %>
       </div>


### PR DESCRIPTION
◯管理者・会員のサインアップ・ログイン・ログアウト後の移動先修正
・admin/sessions_controler
　→ after_sign_in_path_for　、after_sign_out_path_for
・public/registrations_controller
　→ after_sign_up_path_for
・public/session_controller
　→after_sign_in_path_for　、after_sign_out_path_for

◯会員情報編集画面のレイアウト調整